### PR TITLE
SSL/TLS Handshake speed up on Windows CE 6.0

### DIFF
--- a/OpenNETCF.Web/OpenNETCF.Web/Properties/AssemblyInfo.cs
+++ b/OpenNETCF.Web/OpenNETCF.Web/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 #endif
 [assembly: AssemblyCompany("OpenNETCF Consulting, LLC")]
 [assembly: AssemblyProduct("OpenNETCF.Web")]
-[assembly: AssemblyCopyright("Copyright © 2007-2015 OpenNETCF Consulting, LLC")]
+[assembly: AssemblyCopyright("Copyright © 2007-2018 OpenNETCF Consulting, LLC")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]
@@ -41,8 +41,8 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("OpenNETCF.Web.Test, PublicKey=00240000048000009400000006020000002400005253413100040000010001002beeba3bfe7c548e085cffb8c2b6fd61ddd02b06d70864bb7de8bb22473edf5ab4b2196ff98e232c3e87f11fd7986b743d5d3fdd6ecaf624bacfed116e1cefa50cd652365371d0ebd2702eb1084fed46df79ac0f59f4d66c547918613d565dcf106843f3458516d3cd26f057a346d9f645fc24a7410a095c754835916e13cdbe")]
 [assembly: InternalsVisibleTo("OpenNETCF.Web.Unit.Test")]
 
-[assembly: AssemblyVersion("1.6.16136.0")]
+[assembly: AssemblyVersion("1.6.16137.0")]
 
 #if !WindowsCE
-[assembly: AssemblyFileVersion("1.6.16136.0")]
+[assembly: AssemblyFileVersion("1.6.16137.0")]
 #endif

--- a/OpenNETCF.Web/OpenNETCF.Web/Properties/ChangeLog.txt
+++ b/OpenNETCF.Web/OpenNETCF.Web/Properties/ChangeLog.txt
@@ -93,3 +93,8 @@
 - Added Security configurations, allowing enable/disable of TLS 1.0, 1.1 and 1.2
 - Added Securing configuration to allow enabling specific cipher suites
 - SSL-related bugfixes
+
++=============+
+| 1.6.16137.0 |
++=============+
+- Speed up SSL handshake(Windows CE) by using Certificate from Windows Store as it uses a different Cypto Provider(SecureBlackbox 16)

--- a/OpenNETCF.Web/OpenNETCF.Web/Server/Ssl/ElServerSSLSocket.cs
+++ b/OpenNETCF.Web/OpenNETCF.Web/Server/Ssl/ElServerSSLSocket.cs
@@ -217,18 +217,17 @@ namespace SecureBlackbox.SSLSocket.Server
 			}
 		}
 
-		public SBCustomCertStorage.TElMemoryCertStorage CertStorage
-		{ 
-			get
-			{
-				return (SBCustomCertStorage.TElMemoryCertStorage) SBSSLServer.CertStorage;
-			}
-			set
-			{
-				if (value is SBCustomCertStorage.TElMemoryCertStorage)
-					SBSSLServer.CertStorage = value;
-			}
-		}
+        public SBCustomCertStorage.TElCustomCertStorage CustomCertStorage
+        {
+            get
+            {
+                return SBSSLServer.CertStorage;
+            }
+            set
+            {
+                SBSSLServer.CertStorage = value;
+            }
+        }
 
 		public SBCustomCertStorage.TElCustomCertStorage ClientCertStorage 
 		{ 


### PR DESCRIPTION
When testing on Windows CE and SecureBlackBox V16 found the SSL handshake could take up to 75 seconds on low level x86 platform(800mhz).

This was due to the SecureBlackBox cypto provider being totally written in managed code.  When using a certificate from the Windows store it uses a different provider that uses the Windows Cypto API. 

In our case the handshake time went from 75 seconds to 0.4 sec.